### PR TITLE
Use length-based packet separation

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"io"
+	"log"
 	"net"
+	"os"
 )
 
 // Mainly for testing. Perhaps bots too? I don't know.
@@ -20,7 +22,7 @@ func (c *Client) Connect() error {
 		return err
 	}
 
-	c.conn = &Conn{nc: conn}
+	c.conn = &Conn{nc: conn, l: log.New(os.Stdout, "client: ", logFlags)}
 
 	cr := ConnectRequest{
 		Username: c.Username,

--- a/cmd/gns/example/pillars.gsml
+++ b/cmd/gns/example/pillars.gsml
@@ -1,0 +1,10 @@
+<room>
+  <el name="roof" model="plane" scale-y="-0.1" y="5"/>
+
+  <box name="pillar_bl" scale-y="5" y="2.5" x="-4.5" z="4.5"/>
+  <box name="pillar_fr" scale-y="5" y="2.5" x="4.5" z="-4.5"/>
+  <box name="pillar_br" scale-y="5" y="2.5" x="4.5" z="4.5"/>
+  <box name="pillar_fl" scale-y="5" y="2.5" x="-4.5" z="-4.5"/>
+
+  <plane name="ground" scale-y="2" y="0"/>
+</room>

--- a/cmd/gns/example/room.gsml
+++ b/cmd/gns/example/room.gsml
@@ -1,2 +1,1 @@
-<room>
-</room>
+<room><box name="potato"></box></room>

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,7 @@ var (
 	ErrHandlerNotFound = errors.New("Handler for that command could not be found")
 	ErrPlayerCantJoin  = errors.New("Player is unable to join")
 	ErrUnexpectedCom   = errors.New("Unexpected communication")
+	ErrEmptyBuffer     = errors.New("Buffer is empty")
 
 	ErrClientRejected     = errors.New("Client was rejected by the server")
 	ErrClientNotConnected = errors.New("Client is not connected to a server")

--- a/network.go
+++ b/network.go
@@ -4,9 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net"
+	"strconv"
+	"strings"
 )
 
 const (
@@ -18,62 +21,60 @@ type Networker struct {
 }
 
 func (n *Networker) Handle(conn net.Conn) {
-	c := Conn{nc: conn}
+	c := Conn{nc: conn, l: n.s.log}
 
 	for {
 		com, err := c.ReadCom()
 		if err != nil {
-			log.Println("Couldn't read command:", err)
-			return
+			c.l.Println("Couldn't read command:", err)
+			continue
 		}
 
 		err = n.s.Room.Handle(com.Command, c)
 		if err != nil {
-			log.Println("Unable to respond:", err)
-			return
+			c.l.Println("Unable to respond:", err)
+			continue
 		}
 	}
 }
 
 type Conn struct {
-	nc net.Conn
-
+	nc  net.Conn
 	buf *bytes.Buffer
+	l   *log.Logger
 }
 
 func (c *Conn) ReadCom() (Communication, error) {
-	buf := &bytes.Buffer{}
-	cmd := &bytes.Buffer{}
 	com := Communication{}
 
-	r := bufio.NewReader(c.nc)
-
-	msg, err := r.ReadString('\n')
-	if err != nil {
-		log.Println("coudlnt read from", err)
-		return com, err
-	}
-
-	buf = bytes.NewBufferString(msg)
-	c.buf = buf
-
-	cmd = bytes.NewBuffer(buf.Bytes())
-
-	err = json.NewDecoder(cmd).Decode(&com)
+	_, err := c.ReadRaw()
 	if err != nil {
 		return com, err
 	}
 
-	return com, nil
+	oldBuf := bytes.NewBuffer(c.buf.Bytes())
+	err = c.Read(&com)
+
+	if err == nil {
+		c.buf = oldBuf
+	}
+
+	return com, err
 }
 
 func (c *Conn) Read(v Preparer) error {
-	buf, err := c.ReadRaw()
+	r, err := c.ReadRaw()
 	if err != nil {
 		return err
 	}
 
-	err = json.NewDecoder(buf).Decode(v)
+	buf := &bytes.Buffer{}
+	_, err = buf.ReadFrom(r)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(buf.Bytes(), v)
 
 	c.FlushCache()
 
@@ -82,13 +83,27 @@ func (c *Conn) Read(v Preparer) error {
 
 func (c *Conn) ReadRaw() (io.Reader, error) {
 	if c.buf == nil {
-		buf := bufio.NewReader(c.nc)
-		s, err := buf.ReadString('\n')
+		connBuf := bufio.NewReader(c.nc)
+
+		lenStr, err := connBuf.ReadString('\n')
 		if err != nil {
 			return nil, err
 		}
 
-		c.buf = bytes.NewBufferString(s)
+		lenStr = strings.TrimSpace(lenStr)
+
+		l, err := strconv.Atoi(lenStr)
+		if err != nil {
+			return nil, err
+		}
+
+		buf := make([]byte, l)
+		_, err = connBuf.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+
+		c.buf = bytes.NewBuffer(buf)
 	}
 
 	return c.buf, nil
@@ -106,13 +121,7 @@ func (c *Conn) Send(cmd string, v Preparer) error {
 		return err
 	}
 
-	_, err = c.nc.Write(out)
-	if err != nil {
-		return err
-	}
-
-	_, err = c.nc.Write([]byte("\n"))
-	return err
+	return c.SendRaw(bytes.NewBuffer(out))
 }
 
 func (c *Conn) SendRaw(r io.Reader) error {
@@ -122,10 +131,12 @@ func (c *Conn) SendRaw(r io.Reader) error {
 		return err
 	}
 
-	buf.WriteRune('\n')
+	_, err = c.nc.Write([]byte(fmt.Sprintf("%v\n", buf.Len())))
+	if err != nil {
+		return err
+	}
 
-	io.Copy(c.nc, buf)
-
+	_, err = io.Copy(c.nc, buf)
 	return err
 }
 

--- a/server.go
+++ b/server.go
@@ -1,6 +1,14 @@
 package server
 
-import "net"
+import (
+	"log"
+	"net"
+	"os"
+)
+
+var (
+	logFlags int = log.LstdFlags | log.Lshortfile
+)
 
 type Options struct {
 	Name        string
@@ -18,12 +26,15 @@ type Server struct {
 	Assets *Assets
 
 	Ready chan struct{}
+
+	log *log.Logger
 }
 
 func New(o Options) *Server {
 	s := &Server{
 		Opts:  o,
 		Ready: make(chan struct{}),
+		log:   log.New(os.Stdout, "server: ", logFlags),
 	}
 
 	s.Netw = &Networker{s: s}

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"testing"
 )
@@ -14,6 +16,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
 	server = New(Options{
 		Name:        "Test Server",
 		Description: "Used for testing",
@@ -58,8 +62,18 @@ func TestRequestEnvironment(t *testing.T) {
 }
 
 func TestAssetRequest(t *testing.T) {
-	_, err := client.Asset("main")
+	r, err := client.Asset("main")
 	if err != nil {
-		t.Fatalf("Client could not retrieve asset from server", err)
+		t.Fatal("Client could not retrieve asset from server", err)
+	}
+
+	buf := bytes.Buffer{}
+	_, err = buf.ReadFrom(r)
+	if err != nil {
+		t.Fatal("Couldn't read from asset buffer")
+	}
+
+	if buf.String() != "<room></room>\n" {
+		t.Fatalf("Asset is not the same!")
 	}
 }


### PR DESCRIPTION
This Pull Request changes the way in which packets are separated in the protocol. Instead of using a `\n` symbol to indicate the ending of a packet, the packet is split up into two sections:
- Length
- Payload

The length section tells the responder how long the payload is, it is a number followed by a newline.

The payload is just the raw bytes from the message.

**Example:**

`52\n{"command":"connect_request","username":"harrison"}`

Also. Woo! I'm moving to a PR based workflow. At least on this repository.
